### PR TITLE
Fix make error on file copy

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -161,7 +161,7 @@ bisrv.asd: loader.bin lcd_font.bin crc
 		exit 1; \
 	fi
 
-	$(Q)cp bisrv_08_03.asd bisrv.asd
+	# $(Q)cp bisrv_08_03.asd bisrv.asd
 
 	$(Q)dd if=loader.bin of=bisrv.asd bs=$$(($(LOADER_OFFSET))) seek=1 conv=notrunc 2>/dev/null
 


### PR DESCRIPTION
Commented out this line as the instructions are to copy your bisrv.asd 'as-is' to the folder, so this rename is unnecessary and causes the compile to fall over when it hits this line as it can't find the file to rename it.