### PR TITLE
Automates release build via Github Actions

### DIFF
--- a/.github/scripts/entrypoint.sh
+++ b/.github/scripts/entrypoint.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+dos2unix buildcoresworking.sh
+dos2unix cleanandbuildworking.sh
+
+# TODO: move into separate repo with assets
+wget https://raw.githubusercontent.com/EricGoldsteinNz/SF2000_Resources/main/OS/V1.6/bios/bisrv.asd -O /__w/sf2000_multicore/sf2000_multicore/sdcard
+
+rm -rf sdcard
+./cleancoresworking.sh
+./buildcoresworking.sh
+
+cp -r assets/coreconfig/* /__w/gb300_multicore/gb300_multicore/sdcard/core/config/*
+
+tar -czvf /__w/sf2000_multicore/sf2000_multicore/sf2000_multicore/sf2000-multicore-canary.tar.gz /__w/sf2000_multicore/sf2000_multicore/sdcard

--- a/.github/scripts/entrypoint.sh
+++ b/.github/scripts/entrypoint.sh
@@ -3,12 +3,13 @@ dos2unix buildcoresworking.sh
 dos2unix cleanandbuildworking.sh
 
 # TODO: move into separate repo with assets
-wget https://raw.githubusercontent.com/EricGoldsteinNz/SF2000_Resources/main/OS/V1.6/bios/bisrv.asd -O /__w/sf2000_multicore/sf2000_multicore/sdcard
+wget https://raw.githubusercontent.com/EricGoldsteinNz/SF2000_Resources/main/OS/V1.6/bios/bisrv.asd -O /__w/sf2000_multicore/sf2000_multicore/bisrv_08_03.asd
 
 rm -rf sdcard
 ./cleancoresworking.sh
 ./buildcoresworking.sh
 
-cp -r assets/coreconfig/* /__w/gb300_multicore/gb300_multicore/sdcard/core/config/*
+cp -r assets/coreconfig/* /__w/sf2000_multicore/sf2000_multicore/sdcard/core/config/*
+cp -r README.md /__w/sf2000_multicore/sf2000_multicore/sdcard/README.md
 
-tar -czvf /__w/sf2000_multicore/sf2000_multicore/sf2000_multicore/sf2000-multicore-canary.tar.gz /__w/sf2000_multicore/sf2000_multicore/sdcard
+tar -czvf /__w/sf2000_multicore/sf2000_multicore/sf2000-multicore-canary.tar.gz /__w/sf2000_multicore/sf2000_multicore/sdcard

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,33 @@
+on:
+  push:
+    # Sequence of patterns matched against refs/tags
+    tags:
+      - 'canary*'
+
+name: Create Canary Release
+
+jobs:
+  build:
+    name: Create Canary Release
+    runs-on: ubuntu-20.04
+    container:
+        image: prosty/sf2000-multicore-builder:v1.1-release
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+        with:
+          submodules: 'recursive'
+      - name: Build the release
+        run: ./.github/scripts/entrypoint.sh
+      - name: Upload binaries to release
+        uses: svenstaro/upload-release-action@v2
+        with:
+          prerelease: true
+          repo_token: ${{ secrets.GITHUB_TOKEN }}
+          file: /__w/sf2000_multicore/sf2000_multicore/sf2000-multicore-canary.tar.gz
+          asset_name: sf2000-multicore-${{ github.ref }}.tar.gz
+          tag: ${{ github.ref }}
+          overwrite: true
+          body: |
+              Canary (unstable) build of SF2000 multicore. It contains latest, untested, changes to the emulation cores.
+              Please only use this release prior to backing up your SD card. Kindly report bugs @ our discord server. 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,7 @@
+FROM ubuntu:20.04
+RUN apt-get update
+RUN apt-get -y install git wget build-essential wget dos2unix
+RUN wget https://cloud.maschath.de/s/dDrZN4DSgJ33E3w/download/Codescape.GNU.Tools.Package.2019.09-03-2.for.MIPS32.MTI.Bare.Metal.Ubuntu-18.04.5.x86_64.tar.gz
+RUN tar -xzf Codescape.GNU.Tools.Package.2019.09-03-2.for.MIPS32.MTI.Bare.Metal.Ubuntu-18.04.5.x86_64.tar.gz -C /opt
+
+WORKDIR /app


### PR DESCRIPTION
### Description
This PR:

- adds Dockerfile that spins up a small ubuntu server with all hard dependencies needed to build the release
   - the same docker image/file is used by both docker-compose and github actions
- adds docker-compose.yml to streamline local development (please let me know @madcock , happy to drop this one)
- adds github automation setup that triggers on a new git tag being created, canary*
- adds new submodule with configuration for cores

### How to use/test
- merge this branch
- create a new tag

This can be done via Github webpage, or via cli:
```
 git tag canary-buildtest
```
- push the tag to github
```
 git push origin --tags
```


**Notice:**
- new action has been ran against the repository
- it spins up the docker image, clones all git submodules, builds all working cores
- then it packages them with readme.md and core configuration